### PR TITLE
refactor: feature-redux aspect detection based on getReduxStore method existance

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -43,7 +43,9 @@ function validateFeatureContent() {}
 function assembleFeatureContent() {}
 
 function assembleAspectResources(fassets, aspects) {
-  reducerAspect = aspects.filter(el => el.name === 'reducer').shift();
+  reducerAspect = aspects
+    .filter(el => typeof el.getReduxStore === 'function')
+    .shift();
 
   if (!reducerAspect) {
     throw new Error(


### PR DESCRIPTION
> A more robust way of detecting feature-redux would be to look for a plugin aspect containing the getReduxStore method. The current technique looks for a name of 'reducer', which can vary based on usage. Along the same line, the local variable could be renamed to reduxAspect (very minor).
> https://github.com/KevinAst/feature-redux/issues/15#issuecomment-568642818

