### PR TITLE
refactor: Change the config.storage$ to a mandatory parameter storage on createPersistedReducerAspect

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ yarn add feature-redux-persist
 
 Within your mainline, register the **feature-redux** `reducerAspect` (see `**1**` below) and the **feature-redux-persist** `reducerPersistedAspect` (see `**2**`) to feature-u's [launchApp()](https://feature-u.js.org/cur/api.html#launchApp)
 
-**Note** `**3**` : `persistedReducerAspect` has a required config.storage\$ configuration item (see below)
+**Note** `**3**` : `persistedReducerAspect` has a required storage configuration parameter (see below)
 
 **Note** `**4**` : **ORDER MATTER**, you have to declare `persistedReducerAspect` **before** `reducerAspect` !
 
@@ -45,13 +45,12 @@ Within your mainline, register the **feature-redux** `reducerAspect` (see `**1**
 import {launchApp}                    from 'feature-u';
 import {createReducerAspect}          from 'feature-redux'; // **1**
 import {createPersistedReducerAspect} from 'feature-redux-persist'; // **2**
-import AsyncStorage from '@react-native-community/async-storage'; // for react-native
+import AsyncStorage                   from '@react-native-community/async-storage'; // for react-native
 import features                       from './feature';
 
 export default launchApp({
 
-  const persistedReducerAspect = createPersistedReducerAspect(); // **2**
-  persistedReducerAspect.config.storage$ = AsyncStorage; // **3**
+  const persistedReducerAspect = createPersistedReducerAspect(AsyncStorage); // **2**  **3**
   aspects: [
     persistedReducerAspect,                        // **4**
     createReducerAspect(),                         // **1**
@@ -67,13 +66,23 @@ export default launchApp({
 });
 ```
 
-### Configure
+### Syntax
 
-**config.storage\$**
+```js
++ createPersistedReducerAspect(storage): Aspect
+```
 
-This configuration is _required_.
+#### Parameters
+
+> **storage**
+
+This configuration parameter is _required_.
 
 You can use every storage in that list: https://github.com/rt2zz/redux-persist#storage-engines
+
+> **return value**
+
+An **feature-u** [Aspect](https://feature-u.js.org/cur/api.html#Aspect)
 
 ### Promote reducers
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # feature-redux-persist
 
-`feature-redux-persist` is a [feature-u](https://feature-u.js.org/) integration point to [redux-persist](https://github.com/rt2zz/redux-persist). It promotes the persistedReducerAspect _(a `feautre-u` plugin)_ that facilitates `redux-persist` integration to your features.
+`feature-redux-persist` is a [feature-u](https://feature-u.js.org/) integration point to [redux-persist](https://github.com/rt2zz/redux-persist). It promotes the persistedReducerAspect _(a `feature-u` plugin)_ that facilitates `redux-persist` integration to your features.
 
 `feature-redux-persist` relies on [feature-redux](https://github.com/KevinAst/feature-redux) to provide `redux` integration.
 
 _You have to be aware of feature-u philosophy and know about is implementation before reading this documentation_
 
-[![Build Status](https://travis-ci.com/sylvainlg/feature-redux-persist.svg?branch=master)](https://travis-ci.com/sylvainlg/feature-redux-persist)
+[![Build Status](https://travis-ci.org/sylvainlg/feature-redux-persist.svg?branch=master)](https://travis-ci.org/sylvainlg/feature-redux-persist)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/dfac1457c2ae4ffcb6baf29416de1e9e)](https://www.codacy.com/manual/sylvainlg/feature-redux-persist?utm_source=github.com&utm_medium=referral&utm_content=sylvainlg/feature-redux-persist&utm_campaign=Badge_Grade)
 [![Codacy Badge](https://api.codacy.com/project/badge/Coverage/dfac1457c2ae4ffcb6baf29416de1e9e)](https://www.codacy.com/manual/sylvainlg/feature-redux-persist?utm_source=github.com&utm_medium=referral&utm_content=sylvainlg/feature-redux-persist&utm_campaign=Badge_Coverage)
 [![NPM Version Badge](https://img.shields.io/npm/v/feature-redux-persist.svg)](https://www.npmjs.com/package/feature-redux-persist)

--- a/src/__tests__/index.spec.js
+++ b/src/__tests__/index.spec.js
@@ -7,7 +7,7 @@ describe('createPersistedReducerAspect', () => {
   it('should create a aspect instance', () => {
     const aspect = createPersistedReducerAspect();
     expect(typeof aspect).toBe('object');
-    expect(aspect.name).toBe('persistedreducer');
+    expect(aspect.name).toBe('unused_persistedreducer');
 
     expect(aspect).toMatchObject(
       expect.objectContaining({
@@ -35,18 +35,15 @@ describe('genesis', () => {
   });
 
   it('should be OK with config set', () => {
-    const aspect = createPersistedReducerAspect();
     // dummy object, this will fail in real usage when configuring redux-persist
-    aspect.config.storage$ = {};
-
+    const aspect = createPersistedReducerAspect({});
     expect(aspect.genesis()).toBeNull();
   });
 });
 
 describe('assembleAspectResources', () => {
   it('should fail', () => {
-    const aspect = createPersistedReducerAspect();
-    aspect.config.storage$ = {};
+    const aspect = createPersistedReducerAspect({});
 
     expect(() => aspect.assembleAspectResources({}, [])).toThrow(
       'You must configure feature-redux in order to make feature-redux-persist work'
@@ -54,8 +51,7 @@ describe('assembleAspectResources', () => {
   });
 
   it('should success', () => {
-    const aspect = createPersistedReducerAspect();
-    aspect.config.storage$ = {};
+    const aspect = createPersistedReducerAspect({});
 
     const reducerAspect = createReducerAspect();
     const aspects = [reducerAspect];
@@ -72,8 +68,7 @@ describe('assembleAspectResources', () => {
 
 describe('injectRootAppElm', () => {
   it('should return a PersistGate react element', () => {
-    const aspect = createPersistedReducerAspect();
-    aspect.config.storage$ = {};
+    const aspect = createPersistedReducerAspect({});
 
     const reducerAspect = createReducerAspect();
     const aspects = [reducerAspect];


### PR DESCRIPTION
New API :

```js
+ createPersistedReducerAspect(storage): Aspect
```

BREAKING CHANGE: parameter is now mandatory